### PR TITLE
Fix bug that causes videos to keep playing audio but freeze the video on iOS

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -828,7 +828,6 @@ static int const RCTVideoUnset = -1;
 - (void)setPaused:(BOOL)paused
 {
   if (paused) {
-    [_player pause];
     [_player setRate:0.0];
   } else {
     if([_ignoreSilentSwitch isEqualToString:@"ignore"]) {
@@ -836,7 +835,6 @@ static int const RCTVideoUnset = -1;
     } else if([_ignoreSilentSwitch isEqualToString:@"obey"]) {
       [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
     }
-    [_player play];
     [_player setRate:_rate];
   }
   


### PR DESCRIPTION
Test Plan:
 - the easiet way to test this is to go to the KA app and make this change locally in xcode.
 - Run the app on ios
 - go to a bug of videos
 - keep toggling the speed preference. Keeps doing this over and over again. Before this fix, the video would freeze. After this fix, the video doesn't freeze

https://khanacademy.atlassian.net/browse/MOB-2602