### PR TITLE
Defer setting up of the playerControlsView until it's enabled

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -315,6 +315,10 @@ class ReactExoplayerView extends FrameLayout implements
      */
     private void addPlayerControl() {
         if(player == null) return;
+        // Set up the control view if we haven't yet
+        if (playerControlView == null) {
+            initializePlayerControl();
+        }
         LayoutParams layoutParams = new LayoutParams(
                 LayoutParams.MATCH_PARENT,
                 LayoutParams.MATCH_PARENT);
@@ -390,8 +394,7 @@ class ReactExoplayerView extends FrameLayout implements
                     loadVideoStarted = true;
                 }
 
-                // Initializing the playerControlView
-                initializePlayerControl();
+                // Initializing the playerControlView if needed
                 setControls(controls);
                 applyModifiers();
             }


### PR DESCRIPTION
## Summary:
We pass in `controls={false}`, and so we never want the controls view displayed.
Incidentally, with react-native 0.60.0 we get a crash at line 291, because `R.id.exo_play_pause_contrainer` isn't defined.
I started down the rabbit hole of figuring out why that is, but given that we don't actually use the controls view,
this ended up being a short + sweet fix.
It's still probably a good idea to figure out what's going on with the resources at some point.

Issue: MOB-XXXX

## Test plan:
Build & run our app with this change (on the 0.60.0 branch), and see that videos play! And it doesn't crash!